### PR TITLE
Updates to Singularity recipe

### DIFF
--- a/Singularity.swist
+++ b/Singularity.swist
@@ -1,23 +1,21 @@
-#!/bin/bash
-
 Bootstrap: docker
 From: nipype/nipype:latest
 
+# This is the adjusted (fixed) build recipe for the issue above.
+# sudo singularity build swist Singularity.swist
+
 %labels
-  Maintainer Natalia
-  Version v1.0
+    Maintainer Natalia
+    Version v1.0
+
+%environment
+    . /opt/conda/bin/activate neuro
 
 %post
-  # Install nano
-  apt-get update
-  apt-get install nano
+    # Install nano
+    apt-get update && apt-get install -y nano
 
-  # Set up Python environment
-  CONDA_ENV=/opt/conda/bin
-  export PATH=$CONDA_ENV:$PATH
-  chmod -R 777 $CONDA_ENV
-
-  # Activate conda environment
-  conda activate neuro
-  conda install seaborn
-  pip install pybids
+    # Install into conda environment
+    . /opt/conda/bin/activate neuro &&
+    /opt/conda/bin/conda install --name neuro -y seaborn &&
+    /opt/conda/envs/neuro/bin/pip install pybids


### PR DESCRIPTION
This coincides with an image that builds! The usage is as follows:

```bash
sudo singularity build swist Singularity.swist
...
Singularity swist:~/Documents/Dropbox/Code/srcc/for-singularity/swist_fmri_image>   . /opt/conda/bin/activate neuro
(neuro) Singularity swist:~/Documents/Dropbox/Code/srcc/for-singularity/swist_fmri_image> python
Python 3.6.5 | packaged by conda-forge | (default, Apr  6 2018, 13:39:56) 
[GCC 4.8.2 20140120 (Red Hat 4.8.2-15)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import seaborn
>>> import nipype
/opt/conda/envs/neuro/lib/python3.6/site-packages/h5py/__init__.py:36: FutureWarning: Conversion of the second argument of issubdtype from `float` to `np.floating` is deprecated. In future, it will be treated as `np.float64 == np.dtype(float).type`.
 from ._conv import register_converters as _register_converters
>>> import bids
>>>
```